### PR TITLE
fix: resolve prompt-to-trace linking race via shared cache

### DIFF
--- a/src/mlflow_dynamodbstore/cache.py
+++ b/src/mlflow_dynamodbstore/cache.py
@@ -2,7 +2,36 @@
 
 from __future__ import annotations
 
+import threading
 from collections import OrderedDict
+
+# Module-level shared cache for trace_id → experiment_id.
+# Solves DynamoDB GSI eventual consistency: start_trace() populates this on one
+# store instance, _resolve_trace_experiment() on a different instance finds it
+# immediately instead of waiting for GSI propagation.
+_shared_trace_exp_cache: OrderedDict[str, str] = OrderedDict()
+_shared_trace_exp_lock = threading.Lock()
+_SHARED_TRACE_CACHE_MAX = 10000
+
+
+def shared_trace_exp_put(trace_id: str, experiment_id: str) -> None:
+    """Record a trace_id → experiment_id mapping visible to all store instances."""
+    with _shared_trace_exp_lock:
+        if trace_id in _shared_trace_exp_cache:
+            _shared_trace_exp_cache.move_to_end(trace_id)
+        else:
+            if len(_shared_trace_exp_cache) >= _SHARED_TRACE_CACHE_MAX:
+                _shared_trace_exp_cache.popitem(last=False)
+        _shared_trace_exp_cache[trace_id] = experiment_id
+
+
+def shared_trace_exp_get(trace_id: str) -> str | None:
+    """Look up a trace_id → experiment_id mapping from the shared cache."""
+    with _shared_trace_exp_lock:
+        if trace_id in _shared_trace_exp_cache:
+            _shared_trace_exp_cache.move_to_end(trace_id)
+            return _shared_trace_exp_cache[trace_id]
+    return None
 
 
 class ResolutionCache:

--- a/src/mlflow_dynamodbstore/tracking_store.py
+++ b/src/mlflow_dynamodbstore/tracking_store.py
@@ -58,7 +58,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_ARTIFACT_LOCATION
 from mlflow.utils.proto_json_utils import milliseconds_to_proto_timestamp
 from mlflow.utils.uri import append_to_uri_path
 
-from mlflow_dynamodbstore.cache import ResolutionCache
+from mlflow_dynamodbstore.cache import ResolutionCache, shared_trace_exp_get, shared_trace_exp_put
 from mlflow_dynamodbstore.dynamodb.config import ConfigReader
 from mlflow_dynamodbstore.dynamodb.fts import (
     fts_diff,
@@ -2301,10 +2301,19 @@ class DynamoDBTrackingStore(AbstractStore):
         return int(time.time()) + days * 86400
 
     def _resolve_trace_experiment(self, trace_id: str) -> str:
-        """Resolve trace_id to experiment_id, using cache then GSI1."""
+        """Resolve trace_id to experiment_id, using caches then GSI1."""
+        # Instance-level cache (fast path for same-instance lookups)
         cached = self._cache.get("trace_exp", trace_id)
         if cached:
             return cached
+
+        # Shared module-level cache (handles cross-instance lookups when
+        # a different store instance wrote start_trace but GSI1 hasn't
+        # propagated yet — DynamoDB GSI eventual consistency)
+        shared = shared_trace_exp_get(trace_id)
+        if shared:
+            self._cache.put("trace_exp", trace_id, shared)
+            return shared
 
         results = self._table.query(
             pk=f"{GSI1_TRACE_PREFIX}{trace_id}",
@@ -2321,6 +2330,7 @@ class DynamoDBTrackingStore(AbstractStore):
         gsi1sk: str = results[0][GSI1_SK]
         experiment_id = gsi1sk[len(PK_EXPERIMENT_PREFIX) :]
         self._cache.put("trace_exp", trace_id, experiment_id)
+        shared_trace_exp_put(trace_id, experiment_id)
         return experiment_id
 
     def start_trace(self, trace_info: TraceInfo) -> TraceInfo:
@@ -2377,8 +2387,9 @@ class DynamoDBTrackingStore(AbstractStore):
 
         self._table.put_item(item, condition="attribute_not_exists(PK)")
 
-        # Cache trace_id -> experiment_id
+        # Cache trace_id -> experiment_id (instance + shared)
         self._cache.put("trace_exp", trace_id, experiment_id)
+        shared_trace_exp_put(trace_id, experiment_id)
 
         # Write CLIENTPTR item if client_request_id is present
         if trace_info.client_request_id:

--- a/tests/unit/test_cache.py
+++ b/tests/unit/test_cache.py
@@ -1,4 +1,43 @@
-from mlflow_dynamodbstore.cache import ResolutionCache
+from mlflow_dynamodbstore.cache import (
+    ResolutionCache,
+    _shared_trace_exp_cache,
+    shared_trace_exp_get,
+    shared_trace_exp_put,
+)
+
+
+class TestSharedTraceExpCache:
+    """Tests for the module-level shared trace_id → experiment_id cache."""
+
+    def setup_method(self):
+        _shared_trace_exp_cache.clear()
+
+    def test_put_and_get(self):
+        shared_trace_exp_put("tr-1", "exp-1")
+        assert shared_trace_exp_get("tr-1") == "exp-1"
+
+    def test_get_miss(self):
+        assert shared_trace_exp_get("nonexistent") is None
+
+    def test_lru_eviction(self):
+        from mlflow_dynamodbstore import cache
+
+        orig = cache._SHARED_TRACE_CACHE_MAX
+        cache._SHARED_TRACE_CACHE_MAX = 2
+        try:
+            shared_trace_exp_put("a", "1")
+            shared_trace_exp_put("b", "2")
+            shared_trace_exp_put("c", "3")  # evicts "a"
+            assert shared_trace_exp_get("a") is None
+            assert shared_trace_exp_get("b") == "2"
+            assert shared_trace_exp_get("c") == "3"
+        finally:
+            cache._SHARED_TRACE_CACHE_MAX = orig
+
+    def test_overwrite_updates_value(self):
+        shared_trace_exp_put("tr-1", "exp-old")
+        shared_trace_exp_put("tr-1", "exp-new")
+        assert shared_trace_exp_get("tr-1") == "exp-new"
 
 
 class TestResolutionCache:

--- a/tests/unit/test_tracking_traces.py
+++ b/tests/unit/test_tracking_traces.py
@@ -1854,6 +1854,35 @@ class TestLinkPromptsToTrace:
         with pytest.raises(MlflowException, match="does not exist"):
             tracking_store.link_prompts_to_trace("nonexistent-trace", [pv])
 
+    def test_link_prompt_cross_instance_resolves_via_shared_cache(self, tracking_store):
+        """Simulate GSI eventual consistency: a second store instance can
+        resolve trace_id→experiment_id via the shared module-level cache
+        even before the GSI propagates."""
+        from mlflow.entities.model_registry import PromptVersion
+
+        from mlflow_dynamodbstore.tracking_store import DynamoDBTrackingStore
+
+        exp_id = _create_experiment(tracking_store)
+        trace_info = _make_trace_info(exp_id, trace_id="tr-cross-instance")
+        tracking_store.start_trace(trace_info)
+
+        # Create a second store instance (empty instance cache, simulating
+        # what happens when the model registry creates a new TracingClient)
+        store2 = DynamoDBTrackingStore(
+            store_uri="dynamodb://us-east-1/test-table?deploy=false",
+            artifact_uri="./mlartifacts",
+        )
+
+        # The second instance should resolve via the shared cache even though
+        # its own instance cache is empty
+        pv = PromptVersion(name="cross-prompt", version=1, template="t")
+        store2.link_prompts_to_trace("tr-cross-instance", [pv])
+
+        fetched = store2.get_trace_info("tr-cross-instance")
+        assert "mlflow.promptVersions" in fetched.tags
+        versions = json.loads(fetched.tags["mlflow.promptVersions"])
+        assert versions[0]["name"] == "cross-prompt"
+
 
 class TestUnlinkTracesFromRun:
     """Tests for unlink_traces_from_run."""


### PR DESCRIPTION
## Summary

- Fixes #18: Prompt-to-trace linking fails silently during demo generation due to DynamoDB GSI eventual consistency
- Adds a module-level shared LRU cache for `trace_id → experiment_id` that all `DynamoDBTrackingStore` instances share
- `start_trace()` populates the shared cache; `_resolve_trace_experiment()` checks it before falling back to GSI1 query
- No retry/sleep needed — the fix is purely cache-based and zero-latency

## Root cause

When the model registry's `link_prompts_to_trace` creates a new `TracingClient` (and thus a new DynamoDB store instance), the instance-level cache is empty. The GSI1 query for `trace_id → experiment_id` may return empty results due to DynamoDB's eventually consistent GSI reads, even though `start_trace()` just wrote the entry on a different store instance.

## Test plan

- [x] New unit test: `test_link_prompt_cross_instance_resolves_via_shared_cache` — verifies a second store instance can resolve via shared cache
- [x] New unit tests for shared cache functions (put, get, miss, eviction, overwrite)
- [x] All 850 unit tests pass
- [x] All 21 integration trace tests pass
- [ ] E2E: demo generation with prompts creates traces with `mlflow.promptVersions` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)