### PR TITLE
fix: add validation, deleted entity checks, and stage transitions

### DIFF
--- a/src/mlflow_dynamodbstore/registry_store.py
+++ b/src/mlflow_dynamodbstore/registry_store.py
@@ -390,7 +390,11 @@ class DynamoDBRegistryStore(AbstractStore):
         page_token: str | None = None,
     ) -> list[RegisteredModel]:
         """Search registered models with filter and order_by support."""
-        from mlflow.utils.search_utils import SearchModelUtils
+        from mlflow.utils.search_utils import SearchModelUtils, SearchUtils
+
+        # Validate order_by clauses (raises on invalid columns/syntax)
+        for clause in order_by or []:
+            SearchUtils.parse_order_by_for_search_registered_models(clause)
 
         from mlflow_dynamodbstore.dynamodb.search import (
             FilterPredicate,
@@ -839,6 +843,8 @@ class DynamoDBRegistryStore(AbstractStore):
 
     def delete_model_version(self, name: str, version: str) -> None:
         """Delete a model version and its tags."""
+        # Verify version exists (raises on deleted/missing versions)
+        self.get_model_version(name, version)
         model_ulid = self._resolve_model_ulid(name)
         padded = _pad_version(version)
         pk = f"{PK_MODEL_PREFIX}{model_ulid}"
@@ -865,6 +871,12 @@ class DynamoDBRegistryStore(AbstractStore):
     ) -> list[ModelVersion]:
         """Search model versions with filter support."""
         import re as _re
+
+        from mlflow.utils.search_utils import SearchModelVersionUtils
+
+        # Validate order_by clauses (raises on invalid columns/syntax)
+        for clause in order_by or []:
+            SearchModelVersionUtils.parse_order_by_for_search_model_versions(clause)
 
         model_name: str | None = None
         run_id_filter: str | None = None

--- a/tests/compatibility/test_registry_compat.py
+++ b/tests/compatibility/test_registry_compat.py
@@ -56,12 +56,6 @@ from tests.store.model_registry.test_sqlalchemy_store import (  # noqa: E402, F4
     test_update_registered_model,
 )
 
-# --- Category 5: update_model_version on deleted version crashes ---
-_xfail_deleted_update = pytest.mark.xfail(
-    reason="DynamoDB store crashes with KeyError on update of deleted model version"
-)
-test_delete_model_version = _xfail_deleted_update(test_delete_model_version)
-
 # --- Category 6: missing SqlAlchemy-internal method ---
 _xfail_sql_internal = pytest.mark.xfail(
     reason="Test uses _get_sql_model_version_including_deleted (SqlAlchemy-specific)"
@@ -115,14 +109,3 @@ _xfail_like = pytest.mark.xfail(
     reason="DynamoDB store only supports prefix LIKE patterns, not infix '%X%'"
 )
 test_search_registered_models = _xfail_like(test_search_registered_models)
-
-# --- Category 15: order_by validation missing ---
-_xfail_orderby_validation = pytest.mark.xfail(
-    reason="DynamoDB store does not validate order_by column names"
-)
-test_search_model_versions_order_by_errors = _xfail_orderby_validation(
-    test_search_model_versions_order_by_errors
-)
-test_search_registered_model_order_by_errors = _xfail_orderby_validation(
-    test_search_registered_model_order_by_errors
-)

--- a/tests/compatibility/test_registry_workspace_compat.py
+++ b/tests/compatibility/test_registry_workspace_compat.py
@@ -21,12 +21,6 @@ from tests.store.model_registry.test_sqlalchemy_workspace_store import (  # noqa
     test_webhook_operations_are_workspace_scoped,
 )
 
-# --- Cross-workspace model version error message mismatch ---
-test_model_version_operations_are_workspace_scoped = pytest.mark.xfail(
-    reason="DynamoDB store raises 'Registered Model not found' instead of 'Model Version not found'"
-)(test_model_version_operations_are_workspace_scoped)
-
-
 # --- Webhooks not implemented ---
 test_webhook_operations_are_workspace_scoped = pytest.mark.xfail(
     reason="DynamoDB store does not implement webhook operations"


### PR DESCRIPTION
## Summary
- Add input validation (`_validate_model_name`, `_validate_registered_model_tag`, `_validate_model_version_tag`) to tag and model operations
- Check version/model exists before mutations — raises on deleted entities
- Use `handle_resource_already_exist_error` for prompt-aware duplicate name detection
- Add stage validation via `get_canonical_stage` (rejects invalid names, normalizes case)
- Implement `archive_existing_versions`: archive other versions in the same stage
- Validate `order_by` clauses in `search_model_versions` and `search_registered_models`
- Check version exists before `delete_model_version` (no silent deletes)

Closes #21

Depends on #25

## Test plan
- [x] 70 compat tests pass, 18 xfailed (up from 66/22)
- [x] Registry workspace: 6 pass, 1 xfail (webhooks only)
- [x] All pre-commit hooks pass (ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)