### PR TITLE
feat: get_latest_versions, rename propagation, model_id lookup

### DIFF
--- a/src/mlflow_dynamodbstore/registry_store.py
+++ b/src/mlflow_dynamodbstore/registry_store.py
@@ -264,10 +264,15 @@ class DynamoDBRegistryStore(AbstractStore):
 
         tags = self._get_model_tags(model_ulid)
         aliases = self._aliases_for_registered_model(model_ulid)
-        return _item_to_registered_model(item, tags, aliases)
+        rm = _item_to_registered_model(item, tags, aliases)
+        rm.latest_versions = self.get_latest_versions(name)
+        return rm
 
     def rename_registered_model(self, name: str, new_name: str) -> RegisteredModel:
         """Rename a registered model."""
+        from mlflow.utils.validation import _validate_model_renaming
+
+        _validate_model_renaming(new_name)
         model_ulid = self._resolve_model_ulid(name)
 
         # Check new name uniqueness
@@ -333,6 +338,12 @@ class DynamoDBRegistryStore(AbstractStore):
             workspace=self._workspace,
         )
         self._table.batch_write(new_fts_items)
+
+        # Update name on all model version items
+        ver_items = self._table.query(pk=pk, sk_prefix=SK_VERSION_PREFIX)
+        for vi in ver_items:
+            if SK_VERSION_TAG_SUFFIX not in vi["SK"]:
+                self._table.update_item(pk=pk, sk=vi["SK"], updates={"name": new_name})
 
         # Invalidate old name cache, cache new name
         self._cache.invalidate("model_name", name)
@@ -726,6 +737,12 @@ class DynamoDBRegistryStore(AbstractStore):
         model_id: str | None = None,
     ) -> ModelVersion:
         """Create a new model version under the given registered model."""
+        if not run_id and model_id:
+            from mlflow import MlflowClient
+
+            model = MlflowClient().get_logged_model(model_id)
+            run_id = model.source_run_id
+
         model_ulid = self._resolve_model_ulid(name)
         pk = f"{PK_MODEL_PREFIX}{model_ulid}"
 
@@ -995,12 +1012,17 @@ class DynamoDBRegistryStore(AbstractStore):
                 results.append(_item_to_model_version(vi, tags))
             return results
 
+        from mlflow.entities.model_registry.model_version_stages import (
+            get_canonical_stage,
+        )
+
         results = []
         for stage in stages:
-            # Query LSI3 where lsi3sk begins_with "stage#"
+            canonical = get_canonical_stage(stage)
+            # Query LSI3 where lsi3sk begins_with "CanonicalStage#"
             stage_items = self._table.query(
                 pk=pk,
-                sk_prefix=f"{stage}#",
+                sk_prefix=f"{canonical}#",
                 index_name="lsi3",
                 scan_forward=False,
                 limit=1,

--- a/tests/compatibility/test_registry_compat.py
+++ b/tests/compatibility/test_registry_compat.py
@@ -62,21 +62,9 @@ _xfail_sql_internal = pytest.mark.xfail(
 )
 test_delete_model_version_redaction = _xfail_sql_internal(test_delete_model_version_redaction)
 
-# --- Category 9: get_latest_versions not implemented ---
-_xfail_latest_versions = pytest.mark.xfail(
-    reason="DynamoDB store get_latest_versions does not filter by stage"
-)
-test_get_latest_versions = _xfail_latest_versions(test_get_latest_versions)
-
-# --- Category 10: rename doesn't propagate to model versions ---
-_xfail_rename = pytest.mark.xfail(
-    reason="DynamoDB store rename_registered_model does not update model version names"
-)
-test_rename_registered_model = _xfail_rename(test_rename_registered_model)
-
-# --- Category 11: model_id lookup not implemented ---
+# --- Category 11: test mocks sqlalchemy_store.MlflowClient, not our module ---
 _xfail_model_id = pytest.mark.xfail(
-    reason="DynamoDB store does not implement model_id lookup in create_model_version"
+    reason="Test mocks sqlalchemy_store.MlflowClient — mock path incompatible with DynamoDB store"
 )
 test_create_model_version_with_model_id_and_no_run_id = _xfail_model_id(
     test_create_model_version_with_model_id_and_no_run_id


### PR DESCRIPTION
## Summary
- **get_latest_versions**: Canonicalize stage names via `get_canonical_stage()` for case-insensitive matching; populate `latest_versions` in `get_registered_model`
- **rename_registered_model**: Propagate new name to all model version items; validate `new_name` via `_validate_model_renaming`
- **create_model_version**: Resolve `run_id` from `model_id` via `MlflowClient().get_logged_model()` when `run_id` is absent
- Remove xfails for Cat 9 and Cat 10; update Cat 11 xfail reason (test mocks sqlalchemy_store path)

Scorecard: **38 passed, 12 xfailed** (up from 34/18 after PR #26)

## Test plan
- [x] `test_get_latest_versions` now passes (was Cat 9 xfail)
- [x] `test_rename_registered_model` now passes (was Cat 10 xfail)
- [x] Cat 11 (`model_id` lookup) implemented but xfailed due to incompatible mock path in vendored test
- [x] 845 unit tests pass
- [x] Full registry compat suite: 38 passed, 12 xfailed

🤖 Generated with [Claude Code](https://claude.com/claude-code)