### PR TITLE
feat: soft-delete model versions with redaction

### DIFF
--- a/docs/superpowers/plans/2026-03-19-model-version-soft-delete.md
+++ b/docs/superpowers/plans/2026-03-19-model-version-soft-delete.md
@@ -1,0 +1,280 @@
+# Model Version Soft-Delete Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace model version hard-delete with soft-delete + redaction, fixing version number reuse and matching MLflow's contract.
+
+**Architecture:** Follow existing soft-delete pattern (experiments/runs/logged models). Use `STAGE_DELETED_INTERNAL` as the deleted marker, redact sensitive fields, set optional TTL, filter deleted versions from all query paths.
+
+**Tech Stack:** DynamoDB, boto3 FilterExpression, MLflow model_version_stages
+
+**Spec:** `docs/superpowers/specs/2026-03-19-model-version-soft-delete.md`
+
+---
+
+## File Structure
+
+- **Modify:** `src/mlflow_dynamodbstore/registry_store.py` — soft-delete, redaction, version counting, filtering
+- **Modify:** `tests/compatibility/test_registry_compat.py` — remove Cat 6 xfail
+
+---
+
+### Task 1: Soft-delete `delete_model_version` with redaction
+
+**Files:**
+- Modify: `src/mlflow_dynamodbstore/registry_store.py:1109-1128`
+
+- [ ] **Step 1: Import `STAGE_DELETED_INTERNAL`**
+
+Add near the top of the file with other MLflow imports:
+```python
+from mlflow.entities.model_registry.model_version_stages import STAGE_DELETED_INTERNAL
+```
+
+- [ ] **Step 2: Rewrite `delete_model_version`**
+
+Replace lines 1109-1128:
+```python
+def delete_model_version(self, name: str, version: str) -> None:
+    """Soft-delete a model version: redact sensitive fields, mark as deleted."""
+    # Verify version exists (raises on deleted/missing versions)
+    self.get_model_version(name, version)
+    model_ulid = self._resolve_model_ulid(name)
+    padded = _pad_version(version)
+    pk = f"{PK_MODEL_PREFIX}{model_ulid}"
+    now_ms = get_current_time_millis()
+
+    # Soft-delete: redact sensitive fields, set deleted stage
+    updates: dict[str, Any] = {
+        "current_stage": STAGE_DELETED_INTERNAL,
+        "source": "REDACTED-SOURCE-PATH",
+        "run_id": "REDACTED-RUN-ID",
+        "run_link": "REDACTED-RUN-LINK",
+        "description": "",
+        "status_message": "",
+        "last_updated_timestamp": now_ms,
+        LSI2_SK: now_ms,
+        LSI3_SK: f"{STAGE_DELETED_INTERNAL}#{padded}",
+    }
+
+    # Optional TTL for eventual hard-delete
+    ttl_seconds = self._config.get_soft_deleted_ttl_seconds()
+    if ttl_seconds is not None:
+        import time
+        updates["ttl"] = int(time.time()) + ttl_seconds
+
+    # Remove sparse index keys so deleted version won't appear in filtered queries
+    removes = [LSI4_SK, LSI5_SK, GSI1_PK, GSI1_SK]
+
+    self._table.update_item(
+        pk=pk,
+        sk=f"{SK_VERSION_PREFIX}{padded}",
+        updates=updates,
+        removes=removes,
+    )
+
+    # Hard-delete tags (no value in keeping redacted version's tags)
+    tag_prefix = f"{SK_VERSION_PREFIX}{padded}{SK_VERSION_TAG_SUFFIX}"
+    tag_items = self._table.query(pk=pk, sk_prefix=tag_prefix)
+    for tag_item in tag_items:
+        self._table.delete_item(pk=pk, sk=tag_item["SK"])
+
+    # Delete aliases pointing to this version
+    for alias_name in self._aliases_for_model_version(model_ulid, int(version)):
+        self._table.delete_item(pk=pk, sk=f"{SK_MODEL_ALIAS_PREFIX}{alias_name}")
+```
+
+- [ ] **Step 3: Run unit tests**
+
+Run: `uv run pytest tests/unit/ -x -q`
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mlflow_dynamodbstore/registry_store.py
+git commit -m "feat: soft-delete model versions with redaction and TTL"
+```
+
+---
+
+### Task 2: Add deleted check to `get_model_version` and internal retrieval method
+
+**Files:**
+- Modify: `src/mlflow_dynamodbstore/registry_store.py:1055-1080`
+
+- [ ] **Step 1: Add deleted check to `get_model_version`**
+
+After line 1076 (the `if item is None` check), add:
+```python
+if item.get("current_stage") == STAGE_DELETED_INTERNAL:
+    raise MlflowException(
+        f"Model Version (name={name}, version={version}) not found",
+        error_code=RESOURCE_DOES_NOT_EXIST,
+    )
+```
+
+- [ ] **Step 2: Add `_get_sql_model_version_including_deleted` method**
+
+After `get_model_version`, add:
+```python
+def _get_sql_model_version_including_deleted(
+    self, name: str, version: str
+) -> ModelVersion:
+    """Retrieve a model version even if soft-deleted (for testing/audit)."""
+    model_ulid = self._resolve_model_ulid(name)
+    padded = _pad_version(version)
+    item = self._table.get_item(
+        pk=f"{PK_MODEL_PREFIX}{model_ulid}",
+        sk=f"{SK_VERSION_PREFIX}{padded}",
+    )
+    if item is None:
+        raise MlflowException(
+            f"Model Version (name={name}, version={version}) not found",
+            error_code=RESOURCE_DOES_NOT_EXIST,
+        )
+    tags = self._get_version_tags(model_ulid, padded)
+    aliases = self._aliases_for_model_version(model_ulid, int(version))
+    return _item_to_model_version(item, tags, aliases)
+```
+
+- [ ] **Step 3: Run unit tests**
+
+Run: `uv run pytest tests/unit/ -x -q`
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/mlflow_dynamodbstore/registry_store.py
+git commit -m "feat: filter deleted model versions from get_model_version, add internal retrieval"
+```
+
+---
+
+### Task 3: Fix version number counting in `create_model_version`
+
+**Files:**
+- Modify: `src/mlflow_dynamodbstore/registry_store.py:997-1001`
+
+- [ ] **Step 1: Replace len-based counting with max-based**
+
+Replace line 1001:
+```python
+# Before:
+next_ver = len(version_items) + 1
+
+# After:
+if version_items:
+    next_ver = max(int(it["version"]) for it in version_items) + 1
+else:
+    next_ver = 1
+```
+
+- [ ] **Step 2: Run unit tests**
+
+Run: `uv run pytest tests/unit/ -x -q`
+Expected: All pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/mlflow_dynamodbstore/registry_store.py
+git commit -m "fix: use max version number instead of count to prevent version reuse"
+```
+
+---
+
+### Task 4: Filter deleted versions from search/list queries
+
+**Files:**
+- Modify: `src/mlflow_dynamodbstore/registry_store.py`
+
+- [ ] **Step 1: Add deleted filter to `_get_versions_for_model` (line ~1410)**
+
+After the tag/non-version skip check, add:
+```python
+if item.get("current_stage") == STAGE_DELETED_INTERNAL:
+    continue
+```
+
+- [ ] **Step 2: Add deleted filter to `_list_all_versions` (line ~1488)**
+
+After the tag skip check, add:
+```python
+if vi.get("current_stage") == STAGE_DELETED_INTERNAL:
+    continue
+```
+
+- [ ] **Step 3: Add deleted filter to `get_latest_versions` no-stages path (line ~1504)**
+
+After filtering out tag items, add:
+```python
+ver_items = [vi for vi in ver_items if vi.get("current_stage") != STAGE_DELETED_INTERNAL]
+```
+
+- [ ] **Step 4: Skip deleted versions in `transition_model_version_stage` archive loop (line ~1623)**
+
+In the loop, after `if vi_padded == padded: continue`, add:
+```python
+if vi.get("current_stage") == STAGE_DELETED_INTERNAL:
+    continue
+```
+
+Also skip tag items in this loop:
+```python
+if SK_VERSION_TAG_SUFFIX in vi["SK"]:
+    continue
+```
+
+- [ ] **Step 5: Run unit tests**
+
+Run: `uv run pytest tests/unit/ -x -q`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/mlflow_dynamodbstore/registry_store.py
+git commit -m "feat: filter deleted model versions from all search/list/transition queries"
+```
+
+---
+
+### Task 5: Remove Cat 6 xfail and verify
+
+**Files:**
+- Modify: `tests/compatibility/test_registry_compat.py`
+
+- [ ] **Step 1: Remove Cat 6 xfail block**
+
+Remove:
+```python
+# --- Category 6: missing SqlAlchemy-internal method ---
+_xfail_sql_internal = pytest.mark.xfail(
+    reason="Test uses _get_sql_model_version_including_deleted (SqlAlchemy-specific)"
+)
+test_delete_model_version_redaction = _xfail_sql_internal(test_delete_model_version_redaction)
+```
+
+- [ ] **Step 2: Run the target test**
+
+Run: `uv run pytest tests/compatibility/test_registry_compat.py::test_delete_model_version_redaction -x -v --runxfail`
+Expected: PASS
+
+- [ ] **Step 3: Run full compat suite**
+
+Run: `uv run pytest tests/compatibility/test_registry_compat.py -v`
+Expected: 45 passed, 5 xfailed.
+
+- [ ] **Step 4: Run unit tests**
+
+Run: `uv run pytest tests/unit/ -x -q`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/compatibility/test_registry_compat.py
+git commit -m "test: remove Cat 6 xfail — soft-delete with redaction now implemented"
+```

--- a/docs/superpowers/specs/2026-03-19-model-version-soft-delete.md
+++ b/docs/superpowers/specs/2026-03-19-model-version-soft-delete.md
@@ -1,0 +1,109 @@
+# Model Version Soft-Delete with Redaction
+
+## Problem
+
+1. **Version number reuse**: `delete_model_version` hard-deletes the item. `create_model_version` calculates `next_ver = len(version_items) + 1`. After deleting version 3 from [1,2,3], the next version is 3 again — reusing a deleted version number.
+
+2. **Missing redaction**: MLflow's contract requires that deleted model versions have sensitive fields (`source`, `run_id`, `run_link`) redacted to `"REDACTED-*"` values. Our hard-delete destroys the evidence entirely.
+
+3. **Inconsistency**: Every other entity (experiments, runs, logged models) uses soft-delete with TTL. Model versions are the only hard-delete.
+
+## Design
+
+Follow the existing soft-delete pattern used by experiments/runs/logged models.
+
+### `delete_model_version` — soft-delete with redaction
+
+Instead of `delete_item`, update the version item:
+
+```python
+updates = {
+    "current_stage": STAGE_DELETED_INTERNAL,  # "Deleted_Internal"
+    "source": "REDACTED-SOURCE-PATH",
+    "run_id": "REDACTED-RUN-ID",
+    "run_link": "REDACTED-RUN-LINK",
+    "description": "",
+    "status_message": "",
+    "last_updated_timestamp": now_ms,
+    LSI2_SK: now_ms,
+    LSI3_SK: f"{STAGE_DELETED_INTERNAL}#{padded}",
+}
+```
+
+Remove sparse LSI keys that would make the deleted version appear in filtered queries:
+```python
+removes = [LSI4_SK, LSI5_SK, GSI1_PK, GSI1_SK]
+```
+
+Set TTL if configured:
+```python
+ttl_seconds = self._config.get_soft_deleted_ttl_seconds()
+if ttl_seconds is not None:
+    updates["ttl"] = int(time.time()) + ttl_seconds
+```
+
+Still hard-delete tags and aliases (same as current).
+
+### `get_model_version` — filter deleted versions
+
+After fetching the item, check for deleted stage:
+```python
+if item.get("current_stage") == STAGE_DELETED_INTERNAL:
+    raise MlflowException(
+        f"Model Version (name={name}, version={version}) not found",
+        error_code=RESOURCE_DOES_NOT_EXIST,
+    )
+```
+
+### `_get_sql_model_version_including_deleted` — internal retrieval
+
+Same as `get_model_version` but without the deleted check. Used by the compatibility test.
+
+### `create_model_version` — fix version counting
+
+Replace `len(version_items) + 1` with max-based approach:
+```python
+version_numbers = [int(it["version"]) for it in version_items]
+next_ver = max(version_numbers) + 1 if version_numbers else 1
+```
+
+This correctly handles gaps from soft-deleted versions.
+
+### Search/list filtering
+
+All query paths that enumerate versions must skip `STAGE_DELETED_INTERNAL` items:
+- `_get_versions_for_model` — already filters via `filter_fn`; add deleted check
+- `_list_all_versions` — add deleted check in loop
+- `get_latest_versions` — add deleted check in loop
+- `_search_versions_by_run_id` — deleted versions have `GSI1_PK`/`GSI1_SK` removed, so they won't appear in GSI1 queries (no change needed)
+- `transition_model_version_stage` — `get_model_version` already rejects deleted (no change needed)
+
+Best approach: use DynamoDB `FilterExpression` to exclude `current_stage = "Deleted_Internal"` at the query level, avoiding Python post-filtering.
+
+### Impact on `archive_existing_versions`
+
+In `transition_model_version_stage`, when archiving existing versions, the loop iterates all versions. Deleted versions should be skipped. Add: `if vi.get("current_stage") == STAGE_DELETED_INTERNAL: continue`.
+
+## Changes
+
+### `src/mlflow_dynamodbstore/registry_store.py`
+
+1. Import `STAGE_DELETED_INTERNAL` from `mlflow.entities.model_registry.model_version_stages`
+2. Rewrite `delete_model_version` to soft-delete with redaction + TTL
+3. Add deleted check to `get_model_version`
+4. Add `_get_sql_model_version_including_deleted` method
+5. Fix `create_model_version` version counting (len → max)
+6. Add `STAGE_DELETED_INTERNAL` filter to `_get_versions_for_model`, `_list_all_versions`, `get_latest_versions`
+7. Skip deleted versions in `transition_model_version_stage` archive loop
+
+### `tests/compatibility/test_registry_compat.py`
+
+8. Remove Cat 6 xfail for `test_delete_model_version_redaction`
+
+## Verification
+
+```bash
+uv run pytest tests/compatibility/test_registry_compat.py::test_delete_model_version_redaction -x -v --runxfail
+uv run pytest tests/compatibility/test_registry_compat.py -v
+uv run pytest tests/unit/ -x -q
+```

--- a/src/mlflow_dynamodbstore/registry_store.py
+++ b/src/mlflow_dynamodbstore/registry_store.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import base64
 import json
+import time
 from typing import Any
 
 from mlflow.entities.model_registry import RegisteredModel, RegisteredModelTag
 from mlflow.entities.model_registry.model_version import ModelVersion
+from mlflow.entities.model_registry.model_version_stages import STAGE_DELETED_INTERNAL
 from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
 from mlflow.entities.model_registry.registered_model_alias import RegisteredModelAlias
 from mlflow.exceptions import MlflowException
@@ -994,11 +996,9 @@ class DynamoDBRegistryStore(AbstractStore):
         model_ulid = self._resolve_model_ulid(name)
         pk = f"{PK_MODEL_PREFIX}{model_ulid}"
 
-        # Determine next version number
-        existing = self._table.query(pk=pk, sk_prefix=SK_VERSION_PREFIX)
-        # Filter out tag items (V#00000001#TAG#key)
-        version_items = [it for it in existing if SK_VERSION_TAG_SUFFIX not in it["SK"]]
-        next_ver = len(version_items) + 1
+        # Atomically increment version counter on model META item
+        counter = self._table.add_attribute(pk, SK_MODEL_META, "next_version", 1)
+        next_ver = int(counter["next_version"])
         padded = _pad_version(next_ver)
 
         now_ms = get_current_time_millis()
@@ -1069,12 +1069,29 @@ class DynamoDBRegistryStore(AbstractStore):
             pk=f"{PK_MODEL_PREFIX}{model_ulid}",
             sk=f"{SK_VERSION_PREFIX}{padded}",
         )
-        if item is None:
+        if item is None or item.get("current_stage") == STAGE_DELETED_INTERNAL:
             raise MlflowException(
                 f"Model Version (name={name}, version={version}) not found",
                 error_code=RESOURCE_DOES_NOT_EXIST,
             )
 
+        tags = self._get_version_tags(model_ulid, padded)
+        aliases = self._aliases_for_model_version(model_ulid, int(version))
+        return _item_to_model_version(item, tags, aliases)
+
+    def _get_sql_model_version_including_deleted(self, name: str, version: str) -> ModelVersion:
+        """Retrieve a model version even if soft-deleted (for testing/audit)."""
+        model_ulid = self._resolve_model_ulid(name)
+        padded = _pad_version(version)
+        item = self._table.get_item(
+            pk=f"{PK_MODEL_PREFIX}{model_ulid}",
+            sk=f"{SK_VERSION_PREFIX}{padded}",
+        )
+        if item is None:
+            raise MlflowException(
+                f"Model Version (name={name}, version={version}) not found",
+                error_code=RESOURCE_DOES_NOT_EXIST,
+            )
         tags = self._get_version_tags(model_ulid, padded)
         aliases = self._aliases_for_model_version(model_ulid, int(version))
         return _item_to_model_version(item, tags, aliases)
@@ -1107,17 +1124,43 @@ class DynamoDBRegistryStore(AbstractStore):
         return _item_to_model_version(updated_item, tags)
 
     def delete_model_version(self, name: str, version: str) -> None:
-        """Delete a model version and its tags."""
+        """Soft-delete a model version: redact sensitive fields, mark as deleted."""
         # Verify version exists (raises on deleted/missing versions)
         self.get_model_version(name, version)
         model_ulid = self._resolve_model_ulid(name)
         padded = _pad_version(version)
         pk = f"{PK_MODEL_PREFIX}{model_ulid}"
+        now_ms = get_current_time_millis()
 
-        # Delete version item
-        self._table.delete_item(pk=pk, sk=f"{SK_VERSION_PREFIX}{padded}")
+        # Soft-delete: redact sensitive fields, set deleted stage
+        updates: dict[str, Any] = {
+            "current_stage": STAGE_DELETED_INTERNAL,
+            "source": "REDACTED-SOURCE-PATH",
+            "run_id": "REDACTED-RUN-ID",
+            "run_link": "REDACTED-RUN-LINK",
+            "description": "",
+            "status_message": "",
+            "last_updated_timestamp": now_ms,
+            LSI2_SK: now_ms,
+            LSI3_SK: f"{STAGE_DELETED_INTERNAL}#{padded}",
+        }
 
-        # Delete version tags
+        # Optional TTL for eventual hard-delete
+        ttl_seconds = self._config.get_soft_deleted_ttl_seconds()
+        if ttl_seconds is not None:
+            updates["ttl"] = int(time.time()) + ttl_seconds
+
+        # Remove sparse index keys so deleted version won't appear in filtered queries
+        removes = [LSI4_SK, LSI5_SK, GSI1_PK, GSI1_SK]
+
+        self._table.update_item(
+            pk=pk,
+            sk=f"{SK_VERSION_PREFIX}{padded}",
+            updates=updates,
+            removes=removes,
+        )
+
+        # Hard-delete tags (no value in keeping redacted version's tags)
         tag_prefix = f"{SK_VERSION_PREFIX}{padded}{SK_VERSION_TAG_SUFFIX}"
         tag_items = self._table.query(pk=pk, sk_prefix=tag_prefix)
         for tag_item in tag_items:
@@ -1405,9 +1448,11 @@ class DynamoDBRegistryStore(AbstractStore):
                 filter_expression=filter_expression,
             )
             for item in items:
-                # Skip tag items and non-version items
+                # Skip tag items, non-version items, and deleted versions
                 sk = item.get("SK", "")
                 if not sk.startswith(SK_VERSION_PREFIX) or SK_VERSION_TAG_SUFFIX in sk:
+                    continue
+                if item.get("current_stage") == STAGE_DELETED_INTERNAL:
                     continue
                 padded = sk.replace(SK_VERSION_PREFIX, "")
                 tags = self._get_version_tags(model_ulid, padded)
@@ -1455,7 +1500,7 @@ class DynamoDBRegistryStore(AbstractStore):
                     pk=f"{PK_MODEL_PREFIX}{model_ulid}",
                     sk=f"{SK_VERSION_PREFIX}{padded}",
                 )
-                if vi is not None:
+                if vi is not None and vi.get("current_stage") != STAGE_DELETED_INTERNAL:
                     tags = self._get_version_tags(model_ulid, padded)
                     versions.append(_item_to_model_version(vi, tags))
         return versions
@@ -1488,6 +1533,8 @@ class DynamoDBRegistryStore(AbstractStore):
             for vi in ver_items:
                 if SK_VERSION_TAG_SUFFIX in vi["SK"]:
                     continue
+                if vi.get("current_stage") == STAGE_DELETED_INTERNAL:
+                    continue
                 padded = vi["SK"].replace(SK_VERSION_PREFIX, "")
                 tags = self._get_version_tags(model_ulid, padded)
                 versions.append(_item_to_model_version(vi, tags))
@@ -1501,7 +1548,12 @@ class DynamoDBRegistryStore(AbstractStore):
         if not stages:
             # Get all versions and determine unique stages
             ver_items = self._table.query(pk=pk, sk_prefix=SK_VERSION_PREFIX)
-            ver_items = [vi for vi in ver_items if SK_VERSION_TAG_SUFFIX not in vi["SK"]]
+            ver_items = [
+                vi
+                for vi in ver_items
+                if SK_VERSION_TAG_SUFFIX not in vi["SK"]
+                and vi.get("current_stage") != STAGE_DELETED_INTERNAL
+            ]
             # Group by stage, pick latest (highest version) per stage
             stage_latest: dict[str, dict[str, Any]] = {}
             for vi in ver_items:
@@ -1533,6 +1585,8 @@ class DynamoDBRegistryStore(AbstractStore):
             )
             if stage_items:
                 vi = stage_items[0]
+                if vi.get("current_stage") == STAGE_DELETED_INTERNAL:
+                    continue
                 padded = vi["SK"].replace(SK_VERSION_PREFIX, "")
                 tags = self._get_version_tags(model_ulid, padded)
                 results.append(_item_to_model_version(vi, tags))
@@ -1621,10 +1675,14 @@ class DynamoDBRegistryStore(AbstractStore):
         if archive_existing_versions:
             version_items = self._table.query(pk=pk, sk_prefix=SK_VERSION_PREFIX)
             for vi in version_items:
+                if SK_VERSION_TAG_SUFFIX in vi["SK"]:
+                    continue
                 vi_padded = vi["SK"].replace(SK_VERSION_PREFIX, "")
                 if vi_padded == padded:
                     continue
                 vi_stage = vi.get("current_stage", "None")
+                if vi_stage == STAGE_DELETED_INTERNAL:
+                    continue
                 if vi_stage == canonical_stage:
                     self._table.update_item(
                         pk=pk,

--- a/tests/compatibility/test_registry_compat.py
+++ b/tests/compatibility/test_registry_compat.py
@@ -58,12 +58,6 @@ from tests.store.model_registry.test_sqlalchemy_store import (  # noqa: E402, F4
     test_update_registered_model,
 )
 
-# --- Category 6: missing SqlAlchemy-internal method ---
-_xfail_sql_internal = pytest.mark.xfail(
-    reason="Test uses _get_sql_model_version_including_deleted (SqlAlchemy-specific)"
-)
-test_delete_model_version_redaction = _xfail_sql_internal(test_delete_model_version_redaction)
-
 # --- Category 11: test mocks sqlalchemy_store.MlflowClient, not our module ---
 _xfail_model_id = pytest.mark.xfail(
     reason="Test mocks sqlalchemy_store.MlflowClient — mock path incompatible with DynamoDB store"


### PR DESCRIPTION
## Summary
- Replace hard-delete with soft-delete for model versions, matching MLflow's contract and existing patterns (experiments, runs, logged models)
- Redact sensitive fields (`source`, `run_id`, `run_link`) on deletion with `REDACTED-*` values
- Use atomic counter on model META item for version numbering, preventing version number reuse after deletion
- Filter deleted versions (`STAGE_DELETED_INTERNAL`) from all query paths: `get_model_version`, `_get_versions_for_model`, `_list_all_versions`, `get_latest_versions`, `_search_versions_by_run_id`, `transition_model_version_stage`
- Add `_get_sql_model_version_including_deleted` for compatibility test support
- Remove Cat 6 xfail — `test_delete_model_version_redaction` now passes

## Test plan
- [x] `test_delete_model_version_redaction` passes (was xfail Cat 6)
- [x] Full registry compat suite: 32 passed, 4 xfailed
- [x] Unit tests: 845 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)