### PR TITLE
fix: resolve Cat 11 MlflowClient mock path for model_id test

### DIFF
--- a/src/mlflow_dynamodbstore/registry_store.py
+++ b/src/mlflow_dynamodbstore/registry_store.py
@@ -7,6 +7,7 @@ import json
 import time
 from typing import Any
 
+from mlflow import MlflowClient
 from mlflow.entities.model_registry import RegisteredModel, RegisteredModelTag
 from mlflow.entities.model_registry.model_version import ModelVersion
 from mlflow.entities.model_registry.model_version_stages import STAGE_DELETED_INTERNAL
@@ -988,8 +989,6 @@ class DynamoDBRegistryStore(AbstractStore):
     ) -> ModelVersion:
         """Create a new model version under the given registered model."""
         if not run_id and model_id:
-            from mlflow import MlflowClient
-
             model = MlflowClient().get_logged_model(model_id)
             run_id = model.source_run_id
 

--- a/tests/compatibility/test_registry_compat.py
+++ b/tests/compatibility/test_registry_compat.py
@@ -58,11 +58,25 @@ from tests.store.model_registry.test_sqlalchemy_store import (  # noqa: E402, F4
     test_update_registered_model,
 )
 
-# --- Category 11: test mocks sqlalchemy_store.MlflowClient, not our module ---
-_xfail_model_id = pytest.mark.xfail(
-    reason="Test mocks sqlalchemy_store.MlflowClient — mock path incompatible with DynamoDB store"
-)
-test_create_model_version_with_model_id_and_no_run_id = _xfail_model_id(
+
+# --- Category 11: redirect MlflowClient mock to our module path ---
+# The vendored test mocks sqlalchemy_store.MlflowClient, but our store imports
+# MlflowClient at module level. Delegate our copy to the sa_store's (possibly mocked) copy.
+def _sync_mlflow_client_mock(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        import mlflow.store.model_registry.sqlalchemy_store as sa_store
+
+        with mock.patch(
+            "mlflow_dynamodbstore.registry_store.MlflowClient",
+            side_effect=lambda: sa_store.MlflowClient(),
+        ):
+            return fn(*args, **kwargs)
+
+    return wrapper
+
+
+test_create_model_version_with_model_id_and_no_run_id = _sync_mlflow_client_mock(
     test_create_model_version_with_model_id_and_no_run_id
 )
 


### PR DESCRIPTION
## Summary
- Move `MlflowClient` import to module level in `registry_store.py` so it's mockable
- Add `_sync_mlflow_client_mock` wrapper (same pattern as `_sync_time_mock`) to delegate our module's `MlflowClient` to the sqlalchemy store's possibly-mocked copy
- Remove Cat 11 xfail — `test_create_model_version_with_model_id_and_no_run_id` now passes

## Test plan
- [x] `test_create_model_version_with_model_id_and_no_run_id` passes (was xfail Cat 11)
- [x] Full registry compat suite: 33 passed, 3 xfailed
- [x] Unit tests: 845 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)