### PR TITLE
fix: validate metric values and convert floats to Decimal

### DIFF
--- a/src/mlflow_dynamodbstore/dynamodb/table.py
+++ b/src/mlflow_dynamodbstore/dynamodb/table.py
@@ -41,6 +41,23 @@ def convert_decimals(obj: Any) -> Any:
     return obj
 
 
+def convert_floats(obj: Any) -> Any:
+    """Recursively convert float values to Decimal for DynamoDB storage.
+
+    DynamoDB's boto3 resource API rejects Python ``float`` values.
+    This converts them to ``Decimal`` before writing.
+    """
+    from decimal import Decimal
+
+    if isinstance(obj, float):
+        return Decimal(str(obj))
+    if isinstance(obj, dict):
+        return {k: convert_floats(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [convert_floats(v) for v in obj]
+    return obj
+
+
 # Attributes that must be numeric (DynamoDB N type) per table schema.
 # All other index key attributes are String (S).
 _NUMERIC_ATTRS: frozenset[str] = frozenset({"lsi2sk"})
@@ -87,6 +104,7 @@ class DynamoDBTable:
     def put_item(self, item: dict[str, Any], condition: str | None = None) -> None:
         """Write an item, with optional ConditionExpression."""
         _validate_index_key_types(item)
+        item = convert_floats(item)
         kwargs: dict[str, Any] = {"Item": item}
         if condition:
             kwargs["ConditionExpression"] = condition
@@ -253,7 +271,7 @@ class DynamoDBTable:
             _validate_index_key_types(item)
         with self._table.batch_writer() as batch:
             for item in items:
-                batch.put_item(Item=item)
+                batch.put_item(Item=convert_floats(item))
 
     def batch_delete(self, keys: list[dict[str, Any]]) -> None:
         """Batch delete items by PK+SK key dicts."""

--- a/src/mlflow_dynamodbstore/tracking_store.py
+++ b/src/mlflow_dynamodbstore/tracking_store.py
@@ -2042,6 +2042,13 @@ class DynamoDBTrackingStore(AbstractStore):
                 new_fts_items.append({"PK": pk, "SK": reverse_sk})
             self._table.batch_write(new_fts_items)
 
+    def log_metric(self, run_id: str, metric: Metric) -> None:
+        """Log a single metric, validating before batch."""
+        from mlflow.utils.validation import _validate_metric
+
+        _validate_metric(metric.key, metric.value, metric.timestamp, metric.step)
+        self.log_batch(run_id, metrics=[metric], params=[], tags=[])
+
     def log_batch(
         self,
         run_id: str,
@@ -2050,6 +2057,10 @@ class DynamoDBTrackingStore(AbstractStore):
         tags: list[RunTag],
     ) -> None:
         """Log a batch of metrics, params, and tags for a run."""
+        from mlflow.utils.validation import _validate_batch_log_data
+
+        metrics, params, tags = _validate_batch_log_data(metrics, params, tags)
+
         experiment_id = self._resolve_run_experiment(run_id)
         pk = f"{PK_EXPERIMENT_PREFIX}{experiment_id}"
 

--- a/tests/compatibility/test_tracking_compat.py
+++ b/tests/compatibility/test_tracking_compat.py
@@ -564,8 +564,6 @@ test_dataset_schema_and_profile_incremental_updates = _xfail_decimal(
     test_dataset_schema_and_profile_incremental_updates
 )
 test_dataset_digest_updates_with_changes = _xfail_decimal(test_dataset_digest_updates_with_changes)
-test_log_null_metric = _xfail_decimal(test_log_null_metric)
-test_log_batch_null_metrics = _xfail_decimal(test_log_batch_null_metrics)
 test_log_metric_allows_multiple_values_at_same_ts_and_run_data_uses_max_ts_value = _xfail_decimal(
     test_log_metric_allows_multiple_values_at_same_ts_and_run_data_uses_max_ts_value
 )


### PR DESCRIPTION
## Summary
- Add `_validate_batch_log_data` in `log_batch` for metric/param/tag validation (rejects null values with proper error messages)
- Override `log_metric` with `_validate_metric` for single-metric validation path
- Add `convert_floats` utility in `table.py` (reverse of `convert_decimals`) — recursively converts Python floats to Decimal before DynamoDB writes
- Apply `convert_floats` in `put_item` and `batch_write`

## Test plan
- [x] `test_log_null_metric` passes (was xfail Cat 9)
- [x] `test_log_batch_null_metrics` passes (was xfail Cat 9)
- [x] Unit tests: 856 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)